### PR TITLE
[Server] quick fix: writePage error handling

### DIFF
--- a/client/src/Pages/WritePage.js
+++ b/client/src/Pages/WritePage.js
@@ -99,7 +99,7 @@ export default function WritePage () {
             title: title,
             content: content,
             imgFile: writeImg,
-            city: city,
+            city: city
           }, {
             withCredentials: true
           }).then((res) => {

--- a/server/controller/articles.js
+++ b/server/controller/articles.js
@@ -87,7 +87,7 @@ const _delete = async (req, res) => {
   try {
     const token = req.cookies.token;
     const data = jwt.verify(token, process.env.SECRET);
-    const author = await User.findOne({ userId: data.userId }, '_id account');
+    const author = await User.findOne({ userId: data.userId }, '_id');
 
     const { id } = req.params;
     const comment = await Comment.findById(id);
@@ -112,14 +112,11 @@ const write = async (req, res) => {
     // Authorization 헤더에 jwt token을 넣고 보낸 요청인 경우
     // req.auth라는 오브젝트 값으로 userId를 받을 수 있다.
 
-    // req.auth를 인식못함.
-    // if (!req.auth) throw 'Unauthorized to write an article. Please sign in.';
-
     const { title, content, imgFile, city } = req.body;
 
     const token = req.cookies.token;
     const data = jwt.verify(token, process.env.SECRET);
-    const author = await User.findOne({ userId: data.userId }, '_id account');
+    const author = await User.findOne({ userId: data.userId }, '_id address');
     const _city = await Region.findOne({ city: city }, '_id');
 
     // 여기서 필요한 userId는 User DB의 _id를 기입합니다.
@@ -133,13 +130,10 @@ const write = async (req, res) => {
       userId: author._id
     });
 
+    const result = await sendtoken5(author.address);
+
     const newDocument = await article.save();
-    const result = await sendtoken5(author.account);
-    if (result) {
-      res.status(201).send(newDocument);
-    } else {
-      res.status(401).send('transaction err');
-    }
+    res.status(201).json({newDocument, result});
   } catch (error) {
     const msg = {};
     msg[`${error.name}`] = `${error.message}`;
@@ -152,7 +146,7 @@ const comment = async (req, res) => {
   try {
     const token = req.cookies.token;
     const data = jwt.verify(token, process.env.SECRET);
-    const author = await User.findOne({ userId: data.userId }, '_id account');
+    const author = await User.findOne({ userId: data.userId }, '_id address');
     const { content, articleId } = req.body;
 
     const comment = new Comment({

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -15,7 +15,8 @@ const schema = new mongoose.Schema({
     required: true
   },
   city: {
-    type: mongoose.ObjectId
+    type: mongoose.ObjectId,
+    required: true
   },
   like: {
     type: [


### PR DESCRIPTION
```
const write = async (req, res) => {
  try {
    // Authorization 헤더에 jwt token을 넣고 보낸 요청인 경우
    // req.auth라는 오브젝트 값으로 userId를 받을 수 있다.

    const { title, content, imgFile, city } = req.body;

    const token = req.cookies.token;
    const data = jwt.verify(token, process.env.SECRET);
    const author = await User.findOne({ userId: data.userId }, '_id account');
    const _city = await Region.findOne({ city: city }, '_id');

    // 여기서 필요한 userId는 User DB의 _id를 기입합니다.
    // 따라서 userId로 User model를 필터하여 필요한 _id 정보만 가져와서
    // userId에 넣습니다.
    const article = new Article({
      title,
      content,
      imgFile,
      city: _city._id,
      userId: author._id
    });

    const newDocument = await article.save();
    const result = await sendtoken5(author.account);
    if (result) {
      res.status(201).send(newDocument);
    } else {
      res.status(401).send('transaction err');
    }

   
  } catch (error) {
    const msg = {};
    msg[`${error.name}`] = `${error.message}`;
    console.error(`${error.name} : ${error.message}`);
    res.status(400).json(msg);
  }
};
```

아티클 올리면 보상 받는 로직 중 author.address가 아닌 account로 보내면서
sendtoken5가 Error: "invalid address (argument="address"라는 오류를 전달함.

한편 article.save() 이 함수는 sendtoken5 이전에 실행되게 코딩되어있어
오류 핸들링 전에 글이 저장되는 버그가 있었음.

article.save()를 sendtoken 이후 실행하도록 변경하고
account라고 잘못 쓰여진 코드를 address로 변경함